### PR TITLE
feat: adapting react-mentions to tiq

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     ],
     "scripts": {
         "build": "preconstruct build",
+        "dev": "preconstruct watch",
         "format": "prettier --write --no-semi --single-quote --trailing-comma es5 \"{src,test,demo/src}/**/*.js\"",
         "lint": "eslint --max-warnings=0 --ext .js src test demo",
         "start": "cross-env NODE_OPTIONS=--openssl-legacy-provider NODE_ENV=development webpack-dev-server --config demo/webpack.config.js",
@@ -44,6 +45,7 @@
         "@babel/core": "^7.4.5",
         "@babel/plugin-proposal-class-properties": "^7.4.4",
         "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
         "@babel/plugin-transform-runtime": "^7.4.4",
         "@babel/polyfill": "^7.4.4",
         "@babel/preset-env": "^7.4.5",

--- a/src/Highlighter.js
+++ b/src/Highlighter.js
@@ -189,7 +189,6 @@ const styled = defaultStyle(
         overflow: "hidden",
         whiteSpace: "pre-wrap",
         wordWrap: "break-word",
-        border: "1px solid transparent",
         textAlign: "start",
 
         "&singleLine": {

--- a/src/MentionsInput.js
+++ b/src/MentionsInput.js
@@ -209,8 +209,14 @@ class MentionsInput extends React.Component {
 
             ...(!readOnly &&
                 !disabled && {
-                    onChange: this.handleChange,
-                    onSelect: this.handleSelect,
+                    onChange: (e) => {
+                        this.handleChange(e);
+                        this.handleSelect(e);
+                    },
+		    // this fixes react-shadow-dom issues:
+		    // React fails to execute `onSelect`- handlers in the shadow DOM,
+		    // that's why we only listen to `onChange` and `onKeyDown` events
+                    // onSelect: this.handleSelect,
                     onKeyDown: this.handleKeyDown,
                     onBlur: this.handleBlur,
                     onCompositionStart: this.handleCompositionStart,
@@ -648,6 +654,16 @@ class MentionsInput extends React.Component {
         if (Object.values(KEY).indexOf(ev.keyCode) >= 0) {
             ev.preventDefault();
             ev.stopPropagation();
+        }
+
+        if (ev.ctrlKey && ev.key === "n") {
+            this.shiftFocus(+1);
+            return;
+        }
+
+        if (ev.ctrlKey && ev.key === "p") {
+            this.shiftFocus(-1);
+            return;
         }
 
         switch (ev.keyCode) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,4 @@
 export { default as MentionsInput } from "./MentionsInput";
 export { default as Mention } from "./Mention";
+export { default as Highlighter } from "./Highlighter";
+export { getMentions } from "./utils";


### PR DESCRIPTION
## Fixes:
- Adding missing dependency 
- Fixing Shadow DOM compatibility:
  - changing `onSelect` trigger to `onChange` (this slightly changes behaviour as well!!) 
  - Reason: `onSelect` is not triggered by react in the shadow DOM
  
## Features:
- Adding a "watch-mode" building as `dev`-script
- Listening to CTRL+n and CTRL+p keybindings